### PR TITLE
Blocks workspace switches while multitasking view toggle animation is active

### DIFF
--- a/src/Deepin/DeepinMultitaskingView.vala
+++ b/src/Deepin/DeepinMultitaskingView.vala
@@ -608,6 +608,14 @@ namespace Gala
 		}
 
 		/**
+		 *
+		 */
+		public bool is_toggling ()
+		{
+			return toggling;
+		}
+
+		/**
 		 * {@inheritDoc}
 		 */
 		public void open (HashTable<string, Variant>? hints = null)

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -71,7 +71,7 @@ namespace Gala
 
         SoundEffect? sound_effect = null;
 		DeepinWindowSwitcher? winswitcher = null;
-		ActivatableComponent? workspace_view = null;
+		DeepinMultitaskingView? workspace_view = null;
 		ActivatableComponent? window_overview = null;
 
 		DeepinWorkspaceName? workspace_name = null;
@@ -236,7 +236,7 @@ namespace Gala
 			plugin_manager.regions_changed.connect (update_input_area);
 
 			if (plugin_manager.workspace_view_provider == null
-				|| (workspace_view = (plugin_manager.get_plugin (plugin_manager.workspace_view_provider) as ActivatableComponent)) == null) {
+				|| (workspace_view = (plugin_manager.get_plugin (plugin_manager.workspace_view_provider) as DeepinMultitaskingView)) == null) {
 				workspace_view = new DeepinMultitaskingView (this);
 				ui_group.add_child ((Clutter.Actor) workspace_view);
 				(workspace_view as DeepinMultitaskingView).connect_key_focus_out_signal ();

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -444,6 +444,9 @@ namespace Gala
 		void handle_switch_to_workspace (Meta.Display display, Meta.Screen screen, Meta.Window? window,
 			Clutter.KeyEvent event, Meta.KeyBinding binding)
 		{
+			if (workspace_view.is_toggling())
+				return;
+
 			var direction = (binding.get_name () == "switch-to-workspace-left" ? MotionDirection.LEFT : MotionDirection.RIGHT);
 			switch_to_next_workspace (direction);
 		}


### PR DESCRIPTION
Fixes #3.

I have solved the problem described in #3 by simply blocking workspace switch commands as long as the multitasking view's toggle animation is running. As explained in the git comments, delaying the workspace switch instead of blocking it.

I personally prefer blocking, because I feel like a delay might feel "sluggish" to the user, but we could experiment. Maybe it's hardly recognizable.